### PR TITLE
Fix: Serve static files to resolve 404 error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,1 +1,1 @@
-{"name": "restprova-jules","version": "1.0.0","description": "Reservation system for Delizia Pizza - Node.js/Express backend","main": "server.js","scripts": {"start": "node server.js"},"dependencies": {"express": "^4.18.2","body-parser": "^1.20.2","express-session": "^1.17.3","cors": "^2.8.5"}}
+{"name": "restprova-jules","version": "1.0.0","description": "Reservation system for Delizia Pizza - Node.js/Express backend","main": "server.js","scripts": {"start": "node server.js"},"dependencies": {"express": "^4.18.2","body-parser": "^1.20.2","cors": "^2.8.5"}}

--- a/server.js
+++ b/server.js
@@ -4,6 +4,8 @@ const cors = require('cors');
 const storage = require('./storage');
 const app = express();
 
+app.use(express.static('.'));
+
 app.use(cors());
 app.use(bodyParser.json());
 


### PR DESCRIPTION
The application was returning a "404 Cannot GET /" error because the Express server was not configured to serve static files.

This commit adds the `express.static` middleware to `server.js` to serve files from the root directory, resolving the 404 error and allowing `index.html` to be served at the root path.

Additionally, this commit includes the following changes:
- Removes the unused `express-session` dependency from `package.json`.
- Adds a `.gitignore` file to ignore `node_modules`.